### PR TITLE
changed twitter handle to be accurate

### DIFF
--- a/app/elements/super-header/super-header.html
+++ b/app/elements/super-header/super-header.html
@@ -78,7 +78,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div class="flex social-box layout horizontal end-justified">
           <a class="layout vertical center light-link" href="https://twitter.com/super__core">
             <img class="twitter-logo" src="../../images/twitter.svg"></img>
-            <p class="header-link">@supercore</p>
+            <p class="header-link">@super__core</p>
           </a>
         </div>
       </div>


### PR DESCRIPTION
@Tanbouz 

 I reckon despite it looking uglier, we should use the actual twitter handle here. The alternative is removing the @ so it's clear its not absolute, but then it might be less obvious what the link is.
